### PR TITLE
Expose src/index.js to enabled bundled deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A GitHub App built with Probot that moves issues between repositories.",
   "author": "Armin Sebastian",
   "license": "MIT",
-  "main": "./lib",
+  "main": "./src",
   "repository": "https://github.com/dessant/move-issues",
   "scripts": {
     "start": "probot run ./src/index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A GitHub App built with Probot that moves issues between repositories.",
   "author": "Armin Sebastian",
   "license": "MIT",
+  "main": "./lib",
   "repository": "https://github.com/dessant/move-issues",
   "scripts": {
     "start": "probot run ./src/index.js",


### PR DESCRIPTION
Thanks for this cool probot app! I wanted to deploy it as a [combined app](https://probot.github.io/docs/deployment/#combining-apps) and probot complained that it could not find `move-issues`. There are two options to solve this problem: Either put the `index.js` or a proxy file to the root level of your repo or add the `main` entry to `package.json` pointing there. After this fix it works like a charm!  