### PR TITLE
Remove dots that breaks GitHub auto-linking

### DIFF
--- a/src/move.js
+++ b/src/move.js
@@ -267,7 +267,7 @@ module.exports = class Move {
         body:
           `*${issueAuthorMention} commented on ${issueCreatedAt} UTC:*\n\n` +
           `${this.getMarkdown(sourceIssueData.body_html)}\n\n` +
-          `*This issue was moved by ${cmdAuthorMention} from ${sourceUrl}.*`
+          `*This issue was moved by ${cmdAuthorMention} from ${sourceUrl}*`
       })).data.number;
     }
 

--- a/src/move.js
+++ b/src/move.js
@@ -332,7 +332,7 @@ module.exports = class Move {
         try {
           await sourceGh.issues.createComment({
             ...source,
-            body: `This issue was moved by ${cmdAuthorMention} to ${targetUrl}.`
+            body: `This issue was moved by ${cmdAuthorMention} to ${targetUrl}`
           });
         } catch (e) {
           if (e.code !== 403) {


### PR DESCRIPTION
https://help.github.com/articles/autolinked-references-and-urls/

(This is naive PR, I made it on github.com and I haven't tried out the change for real, sorry for that.)